### PR TITLE
fix: 修复 datePicker 指定 depth 参数后报错, 选项无法拖动

### DIFF
--- a/__tests__/picker.js
+++ b/__tests__/picker.js
@@ -248,4 +248,10 @@ describe('picker', function () {
             done();
         }, closeDur);
     });
+
+    it('test datePicker depth', () => {
+        weui.datePicker({
+            depth: 2
+        });
+    });
 });

--- a/src/picker/scroll.js
+++ b/src/picker/scroll.js
@@ -89,8 +89,10 @@ const getMin = (offset, rowHeight, length) => {
 $.fn.scroll = function (options) {
     const $this = $(this).offAll();
     const $content = $this.find('.weui-picker__content');
+    const item = $content.find('.weui-picker__item')[0];
+    if (!item) return;
 
-    const itemHeight = Math.round($content.find('.weui-picker__item')[0].clientHeight);
+    const itemHeight = Math.round(item.clientHeight);
     const defaults = $.extend({
         items: [],                                  // 数据
         offset: 2,                                  // 列表初始化时的偏移量（列表初始化时，选项是聚焦在中间的，通过offset强制往上挪3项，以达到初始选项是为顶部的那项）


### PR DESCRIPTION
修复 datePicker 指定 depth 参数后报错, 选项无法拖动。